### PR TITLE
Add automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+dist: trusty
+language: python
+cache: pip
+python:
+    - 2.7.13
+    - 3.6
+    - "nightly"  # currently points to Python 3.7.0a0 and pip 9.0.1
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-line-length=127 --statistics
+script:
+    - true  # put other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` is another option once code is stable


### PR DESCRIPTION
The goal of this change is to have Travis-CI automatically run flake8 tests on every pull request. This will help contributors know if their submissions are going to *break the build*. To turn on this **free** service, you would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started/